### PR TITLE
Add rotated detectors to make sure the text is caught

### DIFF
--- a/android/app/src/main/java/com/epfl/dedis/hbt/ui/wallet/ImageAnalyzerProvider.kt
+++ b/android/app/src/main/java/com/epfl/dedis/hbt/ui/wallet/ImageAnalyzerProvider.kt
@@ -1,8 +1,13 @@
 package com.epfl.dedis.hbt.ui.wallet
 
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.media.Image
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.mlkit.vision.MlKitAnalyzer
+import com.google.android.gms.tasks.Task
 import com.google.mlkit.vision.interfaces.Detector
+import java.nio.ByteBuffer
 import java.util.concurrent.Executor
 import javax.inject.Inject
 
@@ -15,10 +20,42 @@ class ImageAnalyzerProvider @Inject constructor() {
         consumer: (T?) -> Unit
     ): ImageAnalysis.Analyzer =
         MlKitAnalyzer(
-            listOf(detector),
+            produceRotationsDetector(detector),
             targetCoordinateSystem,
             executor
         ) {
             consumer(it?.getValue(detector))
         }
+
+    private fun <T> produceRotationsDetector(detector: Detector<T>): List<Detector<T>> =
+        listOf(
+            detector,
+            RotatedDetector(detector, 90),
+            RotatedDetector(detector, -90),
+            RotatedDetector(detector, 180)
+        )
+
+    /** A simple delegation pattern to feed the underlying detector a rotated image */
+    private class RotatedDetector<T>(val detector: Detector<T>, val offset: Int) :
+        Detector<T> by detector {
+
+        override fun process(bitmap: Bitmap, rotation: Int): Task<T> =
+            detector.process(bitmap, rotation + offset)
+
+        override fun process(image: Image, rotation: Int): Task<T> =
+            detector.process(image, rotation + offset)
+
+        override fun process(image: Image, rotation: Int, coordinatesMatrix: Matrix): Task<T> =
+            detector.process(image, rotation + offset, coordinatesMatrix)
+
+        override fun process(
+            byteBuffer: ByteBuffer,
+            width: Int,
+            height: Int,
+            rotation: Int,
+            format: Int
+        ): Task<T> {
+            return detector.process(byteBuffer, width, height, rotation + offset, format)
+        }
+    }
 }


### PR DESCRIPTION
This should make the detection more robust to camera orientation, as it will now try every rotation.

Brute force, also in the way it is implemented

I read every documentation possible, only to realize that this was the easiest way to do it :
A simple delegate that modifies the rotation argument

 